### PR TITLE
Update license.py

### DIFF
--- a/ckanext/dcatapit/model/license.py
+++ b/ckanext/dcatapit/model/license.py
@@ -55,7 +55,7 @@ class License(DeclarativeBase, DomainObject):
                                                   remote_side=[id]),
                               lazy=True)
 
-    DEFAULT_LICENSE = 'https://w3id.org/italia/controlled-vocabulary/licences/C1_Unknown'
+    DEFAULT_LICENSE = 'https://w3id.org/italia/controlled-vocabulary/licences/A21_CCBY40'
 
     @classmethod
     def q(cls):


### PR DESCRIPTION
in caso di non mapping, è meglio non mettere licenza sconosciuta ma quella indicata da AGID come licenza di default (A21_CCBY40)