### PR TITLE
Restore help tooltips

### DIFF
--- a/ckanext/dcatapit/fanstatic/dcatapit.css
+++ b/ckanext/dcatapit/fanstatic/dcatapit.css
@@ -617,3 +617,37 @@ ul.ui-tabs-nav {
 .select2-container-multi .select2-search-choice-close {
   top: 4px!important;
 }
+
+[data-title]:hover:after {
+    opacity: 1;
+    transition: all 0.1s ease 0.5s;
+    visibility: visible;
+}
+
+[data-title]:after {
+    content: attr(data-title);
+    position: absolute;
+    bottom: -1.6em;
+    left: 100%;
+    padding: 4px 4px 4px 8px;
+    color: #222;
+    white-space: nowrap; 
+    -moz-border-radius: 5px; 
+    -webkit-border-radius: 5px;  
+    border-radius: 5px;  
+    -moz-box-shadow: 0px 0px 4px #222;  
+    -webkit-box-shadow: 0px 0px 4px #222;  
+    box-shadow: 0px 0px 4px #222;  
+    background-image: -moz-linear-gradient(top, #f8f8f8, #cccccc);  
+    background-image: -webkit-gradient(linear,left top,left bottom,color-stop(0, #f8f8f8),color-stop(1, #cccccc));
+    background-image: -webkit-linear-gradient(top, #f8f8f8, #cccccc);  
+    background-image: -moz-linear-gradient(top, #f8f8f8, #cccccc);  
+    background-image: -ms-linear-gradient(top, #f8f8f8, #cccccc);  
+    background-image: -o-linear-gradient(top, #f8f8f8, #cccccc);
+    opacity: 0;
+    z-index: 99999;
+    visibility: hidden;
+}
+[data-title] {
+    position: relative;
+}

--- a/ckanext/dcatapit/fanstatic/dcatapit.js
+++ b/ckanext/dcatapit/fanstatic/dcatapit.js
@@ -574,17 +574,17 @@ ckan.module('geonames', function($){
  });
 
 
-ckan.module('dcatapit-help', function($){
-    var help = {
-        initialize: function(){
-            $.proxyAll(this, /_on/);
-            $(this.el.find('i')).tooltip();
-        }
-    }
+// ckan.module('dcatapit-help', function($){
+//     var help = {
+//         initialize: function(){
+//             $.proxyAll(this, /_on/);
+//             $(this.el.find('i')).tooltip();
+//         }
+//     }
 
-    return $.extend({}, help);
+//     return $.extend({}, help);
 
- });
+//  });
 
 
 ckan.module('dcatapit-theme', function($){

--- a/ckanext/dcatapit/templates/macros/dcatapit_form_macros.html
+++ b/ckanext/dcatapit/templates/macros/dcatapit_form_macros.html
@@ -480,7 +480,7 @@ Old implementation of the couple element (one element with comma separated value
 {% macro help_block(content) %}
     {% if content %}
         <span class="inline-block" data-module="dcatapit-help">
-      <i class="icon-info-sign size-12" title="{{ content }}"></i>
+      <i class="icon-info-sign size-12" data-title="{{ content }}" title="{{ content }}"></i>
     </span>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
The help tooltips have been restored
![Screenshot 2022-04-21 at 13 15 13](https://user-images.githubusercontent.com/42542676/164499021-2f27071d-4aa3-4c73-8385-f2a6b0d54237.png)
![Screenshot 2022-04-21 at 13 14 44](https://user-images.githubusercontent.com/42542676/164499026-83008b72-e854-488e-93ff-d7e3fda3598a.png)

